### PR TITLE
Silence stderr output when testing if chain exists

### DIFF
--- a/spamhaus.sh
+++ b/spamhaus.sh
@@ -17,7 +17,7 @@ FILE="/tmp/drop.lasso";
 CHAIN="Spamhaus";
 
 # check to see if the chain already exists
-$IPTABLES -L $CHAIN -n
+$IPTABLES -L $CHAIN -n 2>/dev/null
 
 # check to see if the chain already exists
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
When testing iptables if the chain exists, the output to stderr is not necessary if the test fails... if wrapping this program in a cron silencer like cronic https://github.com/justincase/cronic this causes false positives.