### PR TITLE
Fixed 'xtables lock' warning

### DIFF
--- a/spamhaus.sh
+++ b/spamhaus.sh
@@ -5,7 +5,7 @@
 # http://www.cyberciti.biz/tips/block-spamming-scanning-with-iptables.html
 
 # path to iptables
-IPTABLES="/sbin/iptables";
+IPTABLES="/sbin/iptables -w";
 
 # list of known spammers
 URL="www.spamhaus.org/drop/drop.lasso";


### PR DESCRIPTION
You can often see the warning `trying to fix ERROR OUTPUT: `Another app is currently holding the xtables lock. Perhaps you want to use the -w option?` on busy servers where iptables is updated frequently.

Adding the `-w` options fixes this issue by setting maximum wait to acquire xtables lock before give up